### PR TITLE
PCI PT Hotplug/Hotunplug fixes for arch ppc64le

### DIFF
--- a/libvirt/tests/cfg/passthrough/pci/libvirt_pci_passthrough_hotplug.cfg
+++ b/libvirt/tests/cfg/passthrough/pci/libvirt_pci_passthrough_hotplug.cfg
@@ -45,3 +45,9 @@
         - virsh_dump:
             # dump the guest with memory only option
             virsh_dump = "yes"
+        - multiple_hotplug_hotunplug:
+            multiple_hotplug_hotunplug = "yes"
+            number_of_hotplug_unplug = 25
+        - multiple_hotplug_unplug_with_rand_reboot:
+            random_reboot = "yes"
+            number_of_hotplug_unplug = 30


### PR DESCRIPTION
1) Added 2 new test cases :
   test 1 :  hotplog/unplug operation is performed for multiple times
   test 2 :  multiple hotplug/unplug operations with random reboot is done in between to check device avialability inside VM.
2) Changes made are :
   1) two new parameters added into cfg file
      multiple_hotplug_hotunplug
      number_of_hotplug_unplug
   2) params.itervalues() [supported in python2] was removed in python3. Python3 has params.values() instead. Hence made this change as it was failing to read the params with .itervalues()
   3) The "librtas" package name varies across different distros (fedora, sles etc). Therefore, the test first checks the running distro and adds the corresponding package name to the package list. This approach ensures seamless testing across all supported distributions.
   4) Zip() is the correct and Python 3-compatible way to iterate over two lists in parallel.
   5) For PP64LE arch in latest libvirt it is necessary to detach the device from the host before attaching it to a VM. Hence added a arch 'if' flag to check if the arch is ppc64le and libvirt is latest newer from 3.10 then detach the device from host first then attach it to VM.
   6) utils_net.ping is same, no changes made to the ping function, just added timeout=30 sec and passing session handler to the same ping function, so that ping command is executed inside VM , as my requirement is to run ping test inside VM for the interface added for a pci device.
   7) rand_reboot function is added. The function is designed where it Set probability of reboot per iteration (e.g., 30%) and based on total number of iterations and probability a random reboot happens in between hotplug/unplug operations. On an average for 30 iterations 6-8 reboots are expected.
   8) Both the tests are called inside try block