### PR TITLE
The patch fixes most of the failures from libvirt_mem for arch ppc64

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -31,6 +31,9 @@
             test_managedsave = "yes"
             test_save_restore = "yes"
             mem_online = "no"
+            ppc64,ppc64le:
+                max_mem_rt = 3145728
+                tg_size = 1048576
             variants:
                 - mem_basic:
                     max_mem_rt = 2560000
@@ -38,6 +41,8 @@
                     current_mem = 1536000
                     numa_cells = "{'id':'0','cpus':'0-1','memory':'1024000','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'512000','unit':'KiB'}"
                     test_qemu_cmd = "no"
+                    ppc64,ppc64le:
+                        max_mem_rt = 3145728
                     variants:
                         - default:
                         - cold_plug_discard:
@@ -57,6 +62,8 @@
                             max_mem_slots = 256
                             attach_times = 255
                             numa_cells = "{'id':'0','cpus':'0-1','memory':'4194304','unit':'KiB','discard':'yes'}"
+                            ppc64,ppc64le:
+                                tg_size = 524288
                             variants:
                                 - without_reboot:
                                 # Do not enable hot_reboot until unless it has to be tested.
@@ -205,6 +212,8 @@
                             max_mem_rt = 2622464
                             attach_times = 4
                             attach_option = "--config"
+                            ppc64,ppc64le:
+                                max_mem_rt = 3670016
                         - attach_invalid_size:
                             no pseries
                             tg_size = 512001

--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -231,6 +231,7 @@ def run(test, params, env):
         # Global variable to store max/current memory
         global new_max_mem
         global new_cur_mem
+        arch = platform.machine()
         if attach_option.count("config"):
             dom_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         else:
@@ -240,6 +241,11 @@ def run(test, params, env):
             xml_max_mem = int(dom_xml.max_mem)
             xml_cur_mem = int(dom_xml.current_mem)
             assert int(max_mem_rt) == xml_max_mem_rt
+            cpuxml = dom_xml.cpu
+            numa_cells = cpuxml.numa_cell
+
+            if 'ppc64' in arch:
+                cur_mem = max_mem = sum(int(cell["memory"]) for cell in numa_cells)
 
             # Check attached/detached memory
             logging.info("at_mem=%s,dt_mem=%s", at_mem, dt_mem)
@@ -389,13 +395,19 @@ def run(test, params, env):
 
         if numa_cells:
             cells = [ast.literal_eval(x) for x in numa_cells]
+            arch = platform.machine()
+            min_memory_value = 1048576  # 1 GiB in KiB
             # Rounding the numa memory values
             if align_mem_values:
                 for cell in range(cells.__len__()):
-                    memory_value = str(utils_numeric.align_value(
-                        cells[cell]["memory"],
+                    memory_value = int(cells[cell]["memory"])
+                    if arch == "ppc64le":
+                        memory_value = max(memory_value, min_memory_value)
+                    else:
+                        memory_value = memory_value
+                    cells[cell]["memory"] = str(utils_numeric.align_value(
+                        memory_value,
                         align_to_value))
-                    cells[cell]["memory"] = memory_value
             cpu_xml = vm_xml.VMCPUXML()
             cpu_mode = params.get("cpu_mode", "host-model")
             cpu_xml.xml = "<cpu mode='%s'><numa/></cpu>" % cpu_mode


### PR DESCRIPTION
Based on the test requirements adding/modifying some of the cfg values to make the guest run and flexibly test the scenarios.