### PR TITLE
The fix is provided to settle with maxmemory value changes after performing hotplug operation when hugepages are included.

### DIFF
--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -239,8 +239,12 @@ def run(test, params, env):
             xml_max_mem_rt = int(dom_xml.max_mem_rt)
             xml_max_mem = int(dom_xml.max_mem)
             xml_cur_mem = int(dom_xml.current_mem)
-            assert int(max_mem_rt) == xml_max_mem_rt
-
+            if 'ppc64' in arch:
+                # for arch ppc64 and hugepages, the run time max memory grows and never shrinks.
+                # libvirt rounded max memory boundaries to align with memory block size (usually 64 MiB or 128 MiB)
+                assert int(max_mem_rt) <= xml_max_mem_rt
+            else:
+                assert int(max_mem_rt) == xml_max_mem_rt
             # Check attached/detached memory
             logging.info("at_mem=%s,dt_mem=%s", at_mem, dt_mem)
             logging.info("detach_device is %s", detach_device)


### PR DESCRIPTION
The fix is provided to settle with maxmemory value changes after performing hotplug operation when hugepages are included.

When you add a memory device (model="dimm"), libvirt ensures the max memory is aligned to memory block size (usually 64 MiB or 128 MiB). This is normal behavior for hotplug support.

I have hugepages assigned with 2048kib in the test and test fails when validating max_memory value before and after hotplug operation was performed. The max_memory value had changed after hotplug and the test was failing. After analyses i found that max_memory value got increased by 64Mib to align to memory block size. This is because hotplugging a memory DIMM changes the VM’s runtime maximum memory, and libvirt automatically adjusts <maxMemory> internally.