### PR TITLE
chore(tp-libvirt): fix libvirt connection handling

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -125,6 +125,16 @@ TIMEOUT 3"""
         if not source:
             source = {"network": "default"}
         net_ifs = utils_net.get_net_if(state="UP")
+        # if no interfaces are available in UP state,
+        # iterate through all interfaces with UNKNOWN
+        # state and check if they can be pinged to the
+        # internet through.
+        if len(net_ifs) == 0:
+            unknown_net_ifs = utils_net.get_net_if(state="UNKNOWN")
+            for interface in unknown_net_ifs:
+                if utils_net.ping(dest="google.com", interface=interface, count=5, timeout=120)[0] == 0:
+                    net_ifs.append(interface)
+                    break
         # Check source device is valid or not,
         # if it's not in host interface list, try to set
         # source device to first active interface of host

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -104,6 +104,16 @@ def run(test, params, env):
         source = iface_source
         if source:
             net_ifs = utils_net.get_net_if(state="UP")
+            # if no interfaces are available in UP state,
+            # iterate through all interfaces with UNKNOWN
+            # state and check if they can be pinged to the
+            # internet through.
+            if len(net_ifs) == 0:
+                unknown_net_ifs = utils_net.get_net_if(state="UNKNOWN")
+                for interface in unknown_net_ifs:
+                    if utils_net.ping(dest="google.com", interface=interface, count=5, timeout=120)[0] == 0:
+                        net_ifs.append(interface)
+                        break
             # Check source device is valid or not,
             # if it's not in host interface list, try to set
             # source device to first active interface of host


### PR DESCRIPTION
The current implementation is looking for interfaces in the UP state, while ignoring interfaces in the UNKNOWN state, which was causing tests to fail on hosts where no interfaces are in the UP state. Added logic to iterate through interfaces in UNKNOWN state, and check which one can be used to ping to the outside world, then using the same interface for the purpose of the tests where it is required.