### PR TITLE
virtual_network: respect configurable preferred interface state

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -4,6 +4,7 @@
     start_vm = "no"
     status_error = "no"
     start_error = "no"
+    preferred_iface_state = "UP"
     variants:
         - rom_test:
             variants:

--- a/libvirt/tests/cfg/virtual_network/iface_options.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_options.cfg
@@ -4,6 +4,7 @@
     start_vm = "no"
     status_error = "no"
     start_error = "no"
+    preferred_iface_state = "UP"
     variants:
         - iface_source_default:
             test_iface_option_cmd = "yes"

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -124,7 +124,12 @@ TIMEOUT 3"""
         source = ast.literal_eval(iface_source)
         if not source:
             source = {"network": "default"}
-        net_ifs = utils_net.get_net_if(state="UP")
+        preferred_state = params.get("preferred_iface_state", "UP")
+        net_ifs = utils_net.get_net_if(state=preferred_state)
+        # if no interfaces are available in preferred state,
+        # cancel the test
+        if len(net_ifs) == 0:
+            test.cancel("No active network interface available on host")
         # Check source device is valid or not,
         # if it's not in host interface list, try to set
         # source device to first active interface of host

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -103,7 +103,12 @@ def run(test, params, env):
         del iface.source
         source = iface_source
         if source:
-            net_ifs = utils_net.get_net_if(state="UP")
+            preferred_state = params.get("preferred_iface_state", "UP")
+            net_ifs = utils_net.get_net_if(state=preferred_state)
+            # if no interfaces are available in preferred state,
+            # cancel the test
+            if len(net_ifs) == 0:
+                test.cancel("No active network interface available on host")
             # Check source device is valid or not,
             # if it's not in host interface list, try to set
             # source device to first active interface of host


### PR DESCRIPTION
What
----
Use a config-driven 'preferred_iface_state' parameter to select network interfaces for virtual_network tests. If no interface exists in the preferred state, cancel the test immediately with a clear message.

Why
---
This removes non-deterministic fallback mechanisms and external connectivity dependencies, aligning with tp-libvirt guidance to keep tests simple, environment-independent, and to use test.cancel() for unmet host prerequisites.

How
---
- Read 'preferred_iface_state' from the test params (default: "UP")
- Retrieve interfaces only in that state
- Cancel the test if none are found
- Add logging describing selected interfaces

Behavior
--------
No change when the host provides an interface in the preferred state. Tests cancel cleanly otherwise, preventing ambiguous downstream failures.

Testing
-------
- Verified behavior with preferred_iface_state=UP on hosts with/without UP interfaces
- Confirmed clear cancellation messages appear
- Ran inspekt: inspekt checkall --disable-style E501,E265,W601,E402,E722,E741 --no-license-check

Risk
----
Low. New logic only affects the interface selection stage.